### PR TITLE
Add source structure

### DIFF
--- a/net.mfiano.lisp.stripe.asd
+++ b/net.mfiano.lisp.stripe.asd
@@ -23,6 +23,7 @@
    (:file "card")
    (:file "charge")
    (:file "coupon")
+   (:file "source")
    (:file "credit-note")
    (:file "customer")
    (:file "customer-balance-transaction")

--- a/src/customer.lisp
+++ b/src/customer.lisp
@@ -51,6 +51,7 @@
   coupon
   default-source
   description
+  invoice-settings
   email
   name
   phone

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -1,0 +1,12 @@
+(in-package #:net.mfiano.lisp.stripe)
+
+(define-object source ()
+  id
+  amount
+  currency
+  customer
+  owner
+  redirect
+  statement-descriptor
+  status
+  (type :reader source-type))


### PR DESCRIPTION
Without this, the customer object can fail to read if there are sources attached. I'll fail with saying it can't find stripe:source